### PR TITLE
Dynamically load models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 plotters = { version = "0.3.0" }
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20", features = ["dev-graph"] }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_04_20", features = ["dev-graph", "circuit-params"] }
 num-bigint = "0.4.3"
 hdf5 = "0.8.1"
 ndarray = "0.15.6"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ In this project, we're developing a Halo2 implementation of the [Zero Gravity](h
 There are serveral steps involved to generate proofs:
 - [Rust](https://www.rust-lang.org/tools/install) needs to be installed.
 - Follow the steps from the [`BTHOWeN-zero-g` readme](https://github.com/zkp-gravity/BTHOWeN-zero-g/blob/master/README.md) to train a model, convert it to HDF5 and optionally export the MNIST dataset. Part of the code currently assumes that models are stored in a `models` directory and the MNIST dataset is stored in `data/MNIST/png/`. For example, you can symlink `data -> ../BTHOWeN/software_model/data` and `models -> ../BTHOWeN/software_model/models/MNIST`.
-- `cargo run --release -- predict data/MNIST/png/0000_7.png` classifies a single image.
-- `cargo run --release -- compute-accuracy` computes the accuracy on the MNIST test set. This should yield the same number as the `evaluate.py` script in the `BTHOWeN-zero-g` repository.
-- `cargo run --release -- proof data/MNIST/png/0000_7.png` classifies a single image, generates the keys & proof, and verifies the proof.
+- `cargo run --release -- predict models/model_28input_256entry_1hash_1bpi.pickle.hdf5 data/MNIST/png/0000_7.png` classifies a single image.
+- `cargo run --release -- compute-accuracy models/model_28input_256entry_1hash_1bpi.pickle.hdf5` computes the accuracy on the MNIST test set. This should yield the same number as the `evaluate.py` script in the `BTHOWeN-zero-g` repository.
+- `cargo run --release -- proof models/model_28input_256entry_1hash_1bpi.pickle.hdf5 data/MNIST/png/0000_7.png 17` classifies a single image, generates the keys & proof, and verifies the proof.

--- a/src/gadgets/bloom_filter.rs
+++ b/src/gadgets/bloom_filter.rs
@@ -412,6 +412,7 @@ mod tests {
     impl<F: PrimeField> Circuit<F> for MyCircuit<F> {
         type Config = Config;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()

--- a/src/gadgets/hash.rs
+++ b/src/gadgets/hash.rs
@@ -164,6 +164,7 @@ mod tests {
     impl<F: PrimeField> Circuit<F> for MyCircuit<F> {
         type Config = Config;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()

--- a/src/gadgets/wnn.rs
+++ b/src/gadgets/wnn.rs
@@ -146,30 +146,31 @@ pub struct WnnCircuitConfig {
     instance_column: Column<Instance>,
 }
 
-pub struct WnnCircuit<
-    F: PrimeField,
-    const P: u64,
-    const L: usize,
-    const N_HASHES: usize,
-    const BITS_PER_HASH: usize,
-> {
+#[derive(Clone)]
+pub struct WnnCircuitParams {
+    pub p: u64,
+    pub l: usize,
+    pub n_hashes: usize,
+    pub bits_per_hash: usize,
+}
+
+pub struct WnnCircuit<F: PrimeField> {
     inputs: Vec<u64>,
     bloom_filter_arrays: Array3<bool>,
+    params: WnnCircuitParams,
     _marker: PhantomData<F>,
 }
 
-impl<
-        F: PrimeField,
-        const P: u64,
-        const L: usize,
-        const N_HASHES: usize,
-        const BITS_PER_HASH: usize,
-    > WnnCircuit<F, P, L, N_HASHES, BITS_PER_HASH>
-{
-    pub fn new(inputs: Vec<u64>, bloom_filter_arrays: Array3<bool>) -> Self {
+impl<F: PrimeField> WnnCircuit<F> {
+    pub fn new(
+        inputs: Vec<u64>,
+        bloom_filter_arrays: Array3<bool>,
+        params: WnnCircuitParams,
+    ) -> Self {
         Self {
             inputs,
             bloom_filter_arrays,
+            params,
             _marker: PhantomData,
         }
     }
@@ -187,46 +188,28 @@ impl<
     }
 }
 
-pub struct CircuitParams {
-    p: u64,
-    l: usize,
-    n_hashes: usize,
-    bits_per_hash: usize,
-}
-
-impl Default for CircuitParams {
+impl Default for WnnCircuitParams {
     fn default() -> Self {
-        unimplemented!("Parameters have to be specified by hand!")
+        unimplemented!("Parameters have to be specified manually!")
     }
 }
 
-impl<
-        F: PrimeField,
-        const P: u64,
-        const L: usize,
-        const N_HASHES: usize,
-        const BITS_PER_HASH: usize,
-    > Circuit<F> for WnnCircuit<F, P, L, N_HASHES, BITS_PER_HASH>
-{
+impl<F: PrimeField> Circuit<F> for WnnCircuit<F> {
     type Config = WnnCircuitConfig;
     type FloorPlanner = SimpleFloorPlanner;
-    type Params = CircuitParams;
+    type Params = WnnCircuitParams;
 
     fn without_witnesses(&self) -> Self {
         Self {
             inputs: vec![],
             bloom_filter_arrays: array![[[]]],
+            params: self.params.clone(),
             _marker: PhantomData,
         }
     }
 
     fn params(&self) -> Self::Params {
-        CircuitParams {
-            p: P,
-            l: L,
-            n_hashes: N_HASHES,
-            bits_per_hash: BITS_PER_HASH,
-        }
+        self.params.clone()
     }
 
     fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
@@ -286,32 +269,38 @@ impl<
         Ok(())
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn configure(_meta: &mut ConstraintSystem<F>) -> Self::Config {
         unimplemented!("configure_with_params should be used!")
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::marker::PhantomData;
 
     use halo2_proofs::dev::MockProver;
     use halo2_proofs::halo2curves::bn256::Fr as Fp;
     use ndarray::array;
 
-    use super::WnnCircuit;
+    use super::{WnnCircuit, WnnCircuitParams};
+
+    const PARAMS: WnnCircuitParams = WnnCircuitParams {
+        p: 17,
+        l: 4,
+        n_hashes: 2,
+        bits_per_hash: 2,
+    };
 
     #[test]
     fn test() {
         let k = 6;
-        let circuit = WnnCircuit::<Fp, 17, 4, 2, 2> {
-            inputs: vec![2, 7],
-            bloom_filter_arrays: array![
+        let circuit = WnnCircuit::<Fp>::new(
+            vec![2, 7],
+            array![
                 [[true, false, true, false], [true, true, false, false],],
                 [[true, false, true, false], [true, true, false, true],],
             ],
-            _marker: PhantomData,
-        };
+            PARAMS,
+        );
 
         // Expected result:
         // - ((2^3 % 17) % 16) = 8 -> Indices 2 & 0
@@ -326,14 +315,14 @@ mod tests {
 
     #[test]
     fn plot() {
-        WnnCircuit::<Fp, 17, 4, 2, 2> {
-            inputs: vec![2, 7],
-            bloom_filter_arrays: array![
+        WnnCircuit::<Fp>::new(
+            vec![2, 7],
+            array![
                 [[true, false, true, false], [true, true, false, false],],
                 [[true, false, true, false], [true, true, false, true],],
             ],
-            _marker: PhantomData,
-        }
+            PARAMS,
+        )
         .plot("wnn-layout.png", 6);
     }
 }

--- a/src/io/image.rs
+++ b/src/io/image.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use image::ImageError;
 use ndarray::{s, Array, Array2, Array3};
 
-pub fn load_image(img_path: PathBuf) -> Result<Array2<u8>, ImageError> {
+pub fn load_image(img_path: &Path) -> Result<Array2<u8>, ImageError> {
     let image = image::open(img_path)?.to_rgb8();
     let array: Array3<u8> = Array::from_shape_vec(
         (image.height() as usize, image.width() as usize, 3),

--- a/src/io/model.rs
+++ b/src/io/model.rs
@@ -1,11 +1,11 @@
+use std::path::Path;
+
 use hdf5::{File, Result};
 use ndarray::{Ix1, Ix3};
 
 use crate::wnn::Wnn;
 
-pub fn load_wnn<const P: u64, const L: usize, const N_HASHES: usize, const BITS_PER_HASH: usize>(
-    path: &str,
-) -> Result<Wnn<P, L, N_HASHES, BITS_PER_HASH>> {
+pub fn load_wnn(path: &Path) -> Result<Wnn> {
     let file = File::open(path)?;
     for attr_name in file.attr_names()? {
         let attr = file.attr(&attr_name)?.read_scalar::<i64>()?;
@@ -19,11 +19,6 @@ pub fn load_wnn<const P: u64, const L: usize, const N_HASHES: usize, const BITS_
     let num_filter_entries = file.attr("num_filter_entries")?.read_scalar::<i64>()? as usize;
     let num_filter_hashes = file.attr("num_filter_hashes")?.read_scalar::<i64>()? as usize;
     let p = file.attr("p")?.read_scalar::<i64>()? as u64;
-
-    assert_eq!(p, P);
-    assert_eq!(num_filter_entries.pow(num_filter_hashes as u32), 1 << L);
-    assert_eq!(num_filter_hashes, N_HASHES);
-    assert_eq!(num_filter_entries, 1 << BITS_PER_HASH);
 
     let expected_shape = [
         num_classes,
@@ -46,7 +41,7 @@ pub fn load_wnn<const P: u64, const L: usize, const N_HASHES: usize, const BITS_
     let num_input_bits = num_inputs * bits_per_input;
     assert_eq!(input_order.shape(), [num_input_bits]);
 
-    Ok(Wnn::<P, L, N_HASHES, BITS_PER_HASH>::new(
+    Ok(Wnn::new(
         num_classes,
         num_filter_entries,
         num_filter_hashes,


### PR DESCRIPTION
Now, all commands take a `MODEL_PATH` argument. The corresponding model is dynamically loaded and no longer needs to be known at compile time.

Fixes #8 