### PR TITLE
Performance optimization: Instantiate Chips only once

### DIFF
--- a/src/gadgets/bloom_filter.rs
+++ b/src/gadgets/bloom_filter.rs
@@ -10,8 +10,6 @@
 //!   which is set automatically such that the two are roughly equal.
 //!
 //! Both gadgets implement the [`BloomFilterInstructions`] trait and can be used interchangibly.
-use std::marker::PhantomData;
-
 use ff::PrimeFieldBits;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter},
@@ -81,35 +79,38 @@ pub struct BloomFilterChipConfig {
 ///    lookup.
 /// 4. The [`AndBitsChip`] is used to and together the bits.
 pub struct BloomFilterChip<F: PrimeFieldBits> {
-    config: BloomFilterChipConfig,
-    bloom_filter_arrays: Array2<bool>,
-    _marker: PhantomData<F>,
+    array_lookup_chip: ArrayLookupChip<F>,
+    byte_selector_chip: ByteSelectorChip<F>,
+    bit_selector_chip: BitSelectorChip<F>,
+    and_bits_chip: AndBitsChip<F>,
 }
 
 impl<F: PrimeFieldBits> BloomFilterChip<F> {
     /// Constructs a new bloom filter chip.
     pub fn construct(config: BloomFilterChipConfig, bloom_filter_arrays: Array2<bool>) -> Self {
+        let array_lookup_chip =
+            ArrayLookupChip::construct(config.array_lookup_config.clone(), &bloom_filter_arrays);
+        let byte_selector_chip =
+            ByteSelectorChip::<F>::construct(config.byte_selector_config.clone());
+        let bit_selector_chip = BitSelectorChip::<F>::construct(config.bit_selector_config.clone());
+        let and_bits_chip = AndBitsChip::<F>::construct(config.and_bits_config.clone());
+
         Self {
-            config,
-            bloom_filter_arrays,
-            _marker: PhantomData,
+            array_lookup_chip,
+            byte_selector_chip,
+            bit_selector_chip,
+            and_bits_chip,
         }
     }
 
     /// Loads all lookup tables.
     /// Should be called once before [`BloomFilterInstructions::bloom_lookup`]!
     pub fn load(&mut self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
-        let mut array_lookup_chip = ArrayLookupChip::construct(
-            self.config.array_lookup_config.clone(),
-            &self.bloom_filter_arrays,
-        );
-        array_lookup_chip.load(layouter)?;
+        self.array_lookup_chip.load(layouter)?;
 
         // The byte selector reuses the bytes table of the bit selector,
         // so nothing else to be loaded here.
-        let mut bit_selector_chip =
-            BitSelectorChip::<F>::construct(self.config.bit_selector_config.clone());
-        bit_selector_chip.load(layouter)?;
+        self.bit_selector_chip.load(layouter)?;
 
         Ok(())
     }
@@ -167,30 +168,24 @@ impl<F: PrimeFieldBits> BloomFilterInstructions<F> for BloomFilterChip<F> {
         hash_value: AssignedCell<F, F>,
         bloom_index: F,
     ) -> Result<AssignedCell<F, F>, Error> {
-        let array_lookup_chip = ArrayLookupChip::construct(
-            self.config.array_lookup_config.clone(),
-            &self.bloom_filter_arrays,
-        );
-        let byte_selector_chip =
-            ByteSelectorChip::<F>::construct(self.config.byte_selector_config.clone());
-        let bit_selector_chip =
-            BitSelectorChip::<F>::construct(self.config.bit_selector_config.clone());
-        let and_bits_chip = AndBitsChip::<F>::construct(self.config.and_bits_config.clone());
-
-        let lookup_results = array_lookup_chip.array_lookup(layouter, hash_value, bloom_index)?;
+        let lookup_results =
+            self.array_lookup_chip
+                .array_lookup(layouter, hash_value, bloom_index)?;
 
         let mut bits = vec![];
         for lookup_result in lookup_results {
-            let byte = byte_selector_chip.select_byte(
+            let byte = self.byte_selector_chip.select_byte(
                 layouter,
                 lookup_result.word,
                 lookup_result.byte_index,
-                array_lookup_chip.bytes_per_word(),
+                self.array_lookup_chip.bytes_per_word(),
             )?;
-            let bit = bit_selector_chip.select_bit(layouter, byte, lookup_result.bit_index)?;
+            let bit = self
+                .bit_selector_chip
+                .select_bit(layouter, byte, lookup_result.bit_index)?;
             bits.push(bit);
         }
-        let result = and_bits_chip.and_bits(layouter, bits)?;
+        let result = self.and_bits_chip.and_bits(layouter, bits)?;
 
         Ok(result)
     }

--- a/src/gadgets/bloom_filter.rs
+++ b/src/gadgets/bloom_filter.rs
@@ -15,7 +15,7 @@ use halo2_proofs::{
     circuit::{AssignedCell, Layouter},
     plonk::{Advice, Column, ConstraintSystem, Error, TableColumn},
 };
-use ndarray::Array2;
+use ndarray::Array3;
 
 pub use self::{
     and_bits::{AndBitsChip, AndBitsChipConfig, AndBitsInstruction},
@@ -87,9 +87,16 @@ pub struct BloomFilterChip<F: PrimeFieldBits> {
 
 impl<F: PrimeFieldBits> BloomFilterChip<F> {
     /// Constructs a new bloom filter chip.
-    pub fn construct(config: BloomFilterChipConfig, bloom_filter_arrays: Array2<bool>) -> Self {
-        let array_lookup_chip =
-            ArrayLookupChip::construct(config.array_lookup_config.clone(), &bloom_filter_arrays);
+    pub fn construct(config: BloomFilterChipConfig, bloom_filter_arrays: Array3<bool>) -> Self {
+        // Flatten array: from shape (C, N, B) to (C * N, B)
+        let shape = bloom_filter_arrays.shape();
+        let new_shape = (shape[0] * shape[1], shape[2]);
+        let bloom_filter_arrays_flat = bloom_filter_arrays.into_shape(new_shape).unwrap();
+
+        let array_lookup_chip = ArrayLookupChip::construct(
+            config.array_lookup_config.clone(),
+            &bloom_filter_arrays_flat,
+        );
         let byte_selector_chip =
             ByteSelectorChip::<F>::construct(config.byte_selector_config.clone());
         let bit_selector_chip = BitSelectorChip::<F>::construct(config.bit_selector_config.clone());
@@ -202,7 +209,7 @@ mod tests {
         halo2curves::bn256::Fr as Fp,
         plonk::{Advice, Circuit, Column, Instance},
     };
-    use ndarray::Array2;
+    use ndarray::Array3;
 
     use super::{
         BloomFilterChip, BloomFilterChipConfig, BloomFilterConfig, BloomFilterInstructions,
@@ -212,7 +219,7 @@ mod tests {
     struct MyCircuit<F: PrimeFieldBits> {
         input: u64,
         bloom_index: u64,
-        bloom_filter_arrays: Array2<bool>,
+        bloom_filter_arrays: Array3<bool>,
         _marker: PhantomData<F>,
     }
 
@@ -303,7 +310,7 @@ mod tests {
     #[test]
     fn test_all_positive() {
         let k = 14;
-        let bloom_filter_arrays = Array2::<u8>::ones((1, 1024)).mapv(|_| true);
+        let bloom_filter_arrays = Array3::<u8>::ones((1, 1, 1024)).mapv(|_| true);
         let circuit = MyCircuit::<Fp> {
             input: 8,
             bloom_index: 0,
@@ -318,7 +325,7 @@ mod tests {
     #[test]
     fn test_all_negative() {
         let k = 14;
-        let bloom_filter_arrays = Array2::<u8>::ones((1, 1024)).mapv(|_| false);
+        let bloom_filter_arrays = Array3::<u8>::ones((1, 1, 1024)).mapv(|_| false);
         let circuit = MyCircuit::<Fp> {
             input: 8,
             bloom_index: 0,
@@ -333,9 +340,9 @@ mod tests {
     #[test]
     fn test_index_1_2_positive() {
         let k = 14;
-        let mut bloom_filter_arrays = Array2::<u8>::ones((1, 1024)).mapv(|_| false);
-        bloom_filter_arrays[[0, 1]] = true;
-        bloom_filter_arrays[[0, 2]] = true;
+        let mut bloom_filter_arrays = Array3::<u8>::ones((1, 1, 1024)).mapv(|_| false);
+        bloom_filter_arrays[[0, 0, 1]] = true;
+        bloom_filter_arrays[[0, 0, 2]] = true;
         let circuit = MyCircuit::<Fp> {
             input: 0b0000000001_0000000010,
             bloom_index: 0,
@@ -350,9 +357,9 @@ mod tests {
     #[test]
     fn test_index_1_2_negative() {
         let k = 14;
-        let mut bloom_filter_arrays = Array2::<u8>::ones((1, 1024)).mapv(|_| false);
-        bloom_filter_arrays[[0, 0]] = true;
-        bloom_filter_arrays[[0, 2]] = true;
+        let mut bloom_filter_arrays = Array3::<u8>::ones((1, 1, 1024)).mapv(|_| false);
+        bloom_filter_arrays[[0, 0, 0]] = true;
+        bloom_filter_arrays[[0, 0, 2]] = true;
         let circuit = MyCircuit::<Fp> {
             input: 0b0000000001_0000000010,
             bloom_index: 0,
@@ -374,7 +381,7 @@ mod tests {
             .titled("Bloom filter Layout", ("sans-serif", 60))
             .unwrap();
 
-        let bloom_filter_arrays = Array2::<u8>::ones((1, 1024)).mapv(|_| true);
+        let bloom_filter_arrays = Array3::<u8>::ones((1, 1, 1024)).mapv(|_| true);
         let circuit = MyCircuit::<Fp> {
             input: 2,
             bloom_index: 0,

--- a/src/gadgets/wnn.rs
+++ b/src/gadgets/wnn.rs
@@ -59,13 +59,13 @@ struct WnnChip<F: PrimeFieldBits> {
 
 impl<F: PrimeFieldBits> WnnChip<F> {
     fn construct(config: WnnChipConfig<F>, bloom_filter_arrays: Array3<bool>) -> Self {
-        let n_classes = bloom_filter_arrays.shape()[0];
-        let n_inputs = bloom_filter_arrays.shape()[1];
+        let shape = bloom_filter_arrays.shape();
+        let n_classes = shape[0];
+        let n_inputs = shape[1];
+        let n_filters = shape[2];
 
         // Flatten array: from shape (C, N, B) to (C * N, B)
-        let shape = bloom_filter_arrays.shape();
-        let new_shape = (shape[0] * shape[1], shape[2]);
-        let bloom_filter_arrays_flat = bloom_filter_arrays.into_shape(new_shape).unwrap();
+        let bloom_filter_arrays_flat = bloom_filter_arrays.into_shape((n_classes * n_inputs, n_filters)).unwrap();
 
         let hash_chip = HashChip::construct(config.hash_chip_config.clone());
         let bloom_filter_chip = BloomFilterChip::construct(

--- a/src/gadgets/wnn.rs
+++ b/src/gadgets/wnn.rs
@@ -62,10 +62,15 @@ impl<F: PrimeFieldBits> WnnChip<F> {
         let n_classes = bloom_filter_arrays.shape()[0];
         let n_inputs = bloom_filter_arrays.shape()[1];
 
+        // Flatten array: from shape (C, N, B) to (C * N, B)
+        let shape = bloom_filter_arrays.shape();
+        let new_shape = (shape[0] * shape[1], shape[2]);
+        let bloom_filter_arrays_flat = bloom_filter_arrays.into_shape(new_shape).unwrap();
+
         let hash_chip = HashChip::construct(config.hash_chip_config.clone());
         let bloom_filter_chip = BloomFilterChip::construct(
             config.bloom_filter_chip_config.clone(),
-            bloom_filter_arrays,
+            &bloom_filter_arrays_flat,
         );
         let response_accumulator_chip =
             ResponseAccumulatorChip::construct(config.response_accumulator_chip_config.clone());

--- a/src/gadgets/wnn.rs
+++ b/src/gadgets/wnn.rs
@@ -24,7 +24,6 @@ pub trait WnnInstructions<F: PrimeFieldBits> {
     fn predict(
         &self,
         layouter: impl Layouter<F>,
-        bloom_filter_arrays: Array3<bool>,
         inputs: Vec<F>,
     ) -> Result<Vec<AssignedCell<F, F>>, Error>;
 }
@@ -43,22 +42,40 @@ pub struct WnnChipConfig<F: PrimeFieldBits> {
 }
 
 /// Implements a BTHOWeN- style weightless neural network.
-/// 
+///
 /// This happens in three steps:
 /// 1. The [`HashChip`] is used to range-check and hash the inputs.
 /// 2. The [`BloomFilterChip`] is used to look up the bloom filter responses
 ///    (for each input and each class).
 /// 3. The [`ResponseAccumulatorChip`] is used to accumulate the responses.
 struct WnnChip<F: PrimeFieldBits> {
-    config: WnnChipConfig<F>,
-    _marker: PhantomData<F>,
+    hash_chip: HashChip<F>,
+    bloom_filter_chip: BloomFilterChip<F>,
+    response_accumulator_chip: ResponseAccumulatorChip<F>,
+
+    n_classes: usize,
+    n_inputs: usize,
 }
 
 impl<F: PrimeFieldBits> WnnChip<F> {
-    fn construct(config: WnnChipConfig<F>) -> Self {
+    fn construct(config: WnnChipConfig<F>, bloom_filter_arrays: Array3<bool>) -> Self {
+        let n_classes = bloom_filter_arrays.shape()[0];
+        let n_inputs = bloom_filter_arrays.shape()[1];
+
+        let hash_chip = HashChip::construct(config.hash_chip_config.clone());
+        let bloom_filter_chip = BloomFilterChip::construct(
+            config.bloom_filter_chip_config.clone(),
+            bloom_filter_arrays,
+        );
+        let response_accumulator_chip =
+            ResponseAccumulatorChip::construct(config.response_accumulator_chip_config.clone());
+
         WnnChip {
-            config,
-            _marker: PhantomData,
+            hash_chip,
+            bloom_filter_chip,
+            response_accumulator_chip,
+            n_classes,
+            n_inputs,
         }
     }
 
@@ -96,49 +113,33 @@ impl<F: PrimeFieldBits> WnnChip<F> {
             response_accumulator_chip_config,
         }
     }
+
+    pub fn load(&mut self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        self.bloom_filter_chip.load(layouter)
+    }
 }
 
 impl<F: PrimeFieldBits> WnnInstructions<F> for WnnChip<F> {
     fn predict(
         &self,
         mut layouter: impl Layouter<F>,
-        bloom_filter_arrays: Array3<bool>,
         inputs: Vec<F>,
     ) -> Result<Vec<AssignedCell<F, F>>, Error> {
-        assert_eq!(bloom_filter_arrays.shape()[1], inputs.len());
-
-        // Flatten array: from shape (C, N, B) to (C * N, B)
-        let shape = bloom_filter_arrays.shape();
-        let bloom_filter_arrays_flat = bloom_filter_arrays
-            .clone()
-            .into_shape((shape[0] * shape[1], shape[2]))
-            .unwrap();
-
-        let hash_chip = HashChip::construct(self.config.hash_chip_config.clone());
-        let mut bloom_filter_chip = BloomFilterChip::<F>::construct(
-            self.config.bloom_filter_chip_config.clone(),
-            bloom_filter_arrays_flat,
-        );
-        let response_accumulator_chip = ResponseAccumulatorChip::<F>::construct(
-            self.config.response_accumulator_chip_config.clone(),
-        );
+        assert_eq!(self.n_inputs, inputs.len());
 
         let hashes = inputs
             .iter()
-            .map(|input| hash_chip.hash(layouter.namespace(|| "hash"), *input))
+            .map(|input| self.hash_chip.hash(layouter.namespace(|| "hash"), *input))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let n_classes = bloom_filter_arrays.shape()[0];
-        bloom_filter_chip.load(&mut layouter)?;
-
         let mut responses = vec![];
-        for c in 0..n_classes {
+        for c in 0..self.n_classes {
             responses.push(Vec::new());
-            for (i, hash) in hashes.clone().iter().enumerate() {
+            for (i, hash) in hashes.clone().into_iter().enumerate() {
                 let array_index = c * hashes.len() + i;
-                responses[c].push(bloom_filter_chip.bloom_lookup(
+                responses[c].push(self.bloom_filter_chip.bloom_lookup(
                     &mut layouter,
-                    hash.clone(),
+                    hash,
                     F::from(array_index as u64),
                 )?);
             }
@@ -147,7 +148,8 @@ impl<F: PrimeFieldBits> WnnInstructions<F> for WnnChip<F> {
         responses
             .iter()
             .map(|class_responses| {
-                response_accumulator_chip.accumulate_responses(&mut layouter, class_responses)
+                self.response_accumulator_chip
+                    .accumulate_responses(&mut layouter, class_responses)
             })
             .collect::<Result<Vec<_>, _>>()
     }
@@ -270,11 +272,12 @@ impl<F: PrimeFieldBits> Circuit<F> for WnnCircuit<F> {
         config: Self::Config,
         mut layouter: impl halo2_proofs::circuit::Layouter<F>,
     ) -> Result<(), halo2_proofs::plonk::Error> {
-        let wnn_chip = WnnChip::construct(config.wnn_chip_config);
+        let mut wnn_chip =
+            WnnChip::construct(config.wnn_chip_config, self.bloom_filter_arrays.clone());
+        wnn_chip.load(&mut layouter)?;
 
         let result = wnn_chip.predict(
             layouter.namespace(|| "wnn"),
-            self.bloom_filter_arrays.clone(),
             self.inputs.iter().map(|v| F::from(*v)).collect(),
         )?;
 


### PR DESCRIPTION
Profiling the current code a little bit, I noticed that the performance optimization in #12 introduced a lot of duplicate computation (in particular, bloom filter bits were packed into field elements over and over again). As a result, circuit synthesis used up around half the proving time!

I fixed this by switching to a pattern where, if a chip uses another chip, it should instantiate it already in the constructor. That way, if a chip is used many times, any one-time computation can happen in the constructor.

The benchmark results compared to `main` branch:

```
benches/proof_generation
                        time:   [1.0382 s 1.0674 s 1.1003 s]
                        change: [-51.766% -49.847% -47.765%] (p = 0.00 < 0.05)
                        Performance has improved.
benches/key_generation  time:   [622.13 ms 655.07 ms 688.86 ms]
                        change: [-76.549% -75.192% -73.880%] (p = 0.00 < 0.05)
                        Performance has improved.
benches/verification    time:   [13.310 ms 14.287 ms 15.066 ms]
                        change: [-4.4483% +4.0829% +13.279%] (p = 0.40 > 0.05)
                        No change in performance detected.
```

(Note that I started using a different computer today, so these numbers are not comparable to numbers in previous PRs. I re-ran the benchmark on `main` though and the reported percentages are correct.)