### PR TITLE
Performance Optimizations

### DIFF
--- a/examples/evm-verifier.rs
+++ b/examples/evm-verifier.rs
@@ -29,10 +29,7 @@ use snark_verifier::{
     verifier::{self, SnarkVerifier},
 };
 use std::{env, fs, path::Path, rc::Rc};
-use zero_g::{
-    checked_in_test_data::{MNIST_TINY, TEST_IMG_PATH},
-    load_grayscale_image, load_wnn,
-};
+use zero_g::{checked_in_test_data::*, load_grayscale_image, load_wnn};
 
 type PlonkVerifier = verifier::plonk::PlonkVerifier<KzgAs<Bn256, Gwc19>>;
 
@@ -271,18 +268,23 @@ fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>)
 }
 
 fn validate_evm<C: Circuit<Fr> + Clone>(circuit: C, instances: Vec<Vec<Fr>>, k: u32, name: &str) {
+    println!("Generating Params...");
     let params = gen_srs(k);
+    println!("Generating PK...");
     let pk = gen_pk(&params, &circuit);
+    println!("Generating deployment code...");
     let deployment_code = gen_evm_verifier(&params, pk.get_vk(), vec![instances[0].len()], name);
 
+    println!("Generating proof...");
     let proof = gen_proof(&params, &pk, circuit.clone(), instances.clone());
+    println!("Verifying proof...");
     evm_verify(deployment_code, instances.clone(), proof);
 }
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args[1] == "wnn" {
-        let (k, model_path) = MNIST_TINY;
+        let (k, model_path) = MNIST_MEDIUM;
 
         let wnn = load_wnn(Path::new(model_path)).unwrap();
         let image = load_grayscale_image(Path::new(TEST_IMG_PATH)).unwrap();

--- a/models/readme.md
+++ b/models/readme.md
@@ -8,7 +8,7 @@ To update the models, follow the steps in the `BTHOWeN-0g` readme, then copy the
 cp ../BTHOWeN/software_model/models/MNIST/*.hdf5 models/
 ```
 
-### "MNIST-Tiny": `model_28input_256entry_1hash_1bpi` (k = 13)
+### "MNIST-Tiny": `model_28input_256entry_1hash_1bpi` (k = 14)
 
 A very small toy model, used in the tests and the benchmark.
 Accuracy on the MNIST test set is 83.06%.

--- a/models/readme.md
+++ b/models/readme.md
@@ -8,7 +8,7 @@ To update the models, follow the steps in the `BTHOWeN-0g` readme, then copy the
 cp ../BTHOWeN/software_model/models/MNIST/*.hdf5 models/
 ```
 
-### "MNIST-Tiny": `model_28input_256entry_1hash_1bpi` (k = 12)
+### "MNIST-Tiny": `model_28input_256entry_1hash_1bpi` (k = 13)
 
 A very small toy model, used in the tests and the benchmark.
 Accuracy on the MNIST test set is 83.06%.

--- a/src/gadgets/encode_image.rs
+++ b/src/gadgets/encode_image.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use ff::PrimeFieldBits;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter},
-    plonk::{Advice, Column, ConstraintSystem, Error, TableColumn},
+    plonk::{Advice, Column, ConstraintSystem, Error},
 };
 use ndarray::{Array2, Array3};
 
@@ -60,11 +60,10 @@ impl<F: PrimeFieldBits> EncodeImageChip<F> {
         y: Column<Advice>,
         diff: Column<Advice>,
         is_gt: Column<Advice>,
-        byte_column: TableColumn,
         range_check_config: RangeCheckConfig<F>,
     ) -> EncodeImageChipConfig<F> {
         let greater_than_chip_config =
-            GreaterThanChip::configure(meta, x, y, diff, is_gt, byte_column, range_check_config);
+            GreaterThanChip::configure(meta, x, y, diff, is_gt, range_check_config);
         EncodeImageChipConfig {
             advice_column: is_gt,
             greater_than_chip_config,

--- a/src/gadgets/encode_image.rs
+++ b/src/gadgets/encode_image.rs
@@ -83,7 +83,7 @@ impl<F: PrimeFieldBits> EncodeImageInstructions<F> for EncodeImageChip<F> {
 
         // Turn Value<Array2<u8>> into Vec<Value<u8>>
         let image_flat = image
-            .map(|image| image.clone().into_iter().collect_vec())
+            .map(|image| image.into_iter().collect_vec())
             .transpose_vec(width * height);
 
         let mut intensity_cells: BTreeMap<(usize, usize), AssignedCell<F, F>> = BTreeMap::new();

--- a/src/gadgets/greater_than.rs
+++ b/src/gadgets/greater_than.rs
@@ -20,7 +20,7 @@ pub trait GreaterThanInstructions<F: PrimeFieldBits> {
     fn greater_than_witness(
         &self,
         layouter: impl Layouter<F>,
-        x: F,
+        x: Value<F>,
         y: F,
     ) -> Result<GreaterThanWitnessResult<F>, Error>;
 
@@ -133,13 +133,13 @@ impl<F: PrimeFieldBits> GreaterThanInstructions<F> for GreaterThanChip<F> {
     fn greater_than_witness(
         &self,
         mut layouter: impl Layouter<F>,
-        x: F,
+        x: Value<F>,
         y: F,
     ) -> Result<GreaterThanWitnessResult<F>, Error> {
         let (x_cell, diff_cell, gt_cell) = layouter.assign_region(
             || "greater_than_witness",
             |mut region| {
-                let x_cell = region.assign_advice(|| "x", self.config.x, 0, || Value::known(x))?;
+                let x_cell = region.assign_advice(|| "x", self.config.x, 0, || x)?;
                 let (diff_cell, result_cell) = self.greater_than(&mut region, &x_cell, y)?;
                 Ok((x_cell, diff_cell, result_cell))
             },
@@ -195,7 +195,7 @@ mod tests {
 
     use ff::{Field, PrimeFieldBits};
     use halo2_proofs::{
-        circuit::{Layouter, SimpleFloorPlanner},
+        circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
         halo2curves::bn256::Fr as Fp,
         plonk::{Circuit, Column, ConstraintSystem, Error, Instance, TableColumn},
@@ -266,7 +266,7 @@ mod tests {
             let greater_than_chip = GreaterThanChip::construct(config.greater_than_config);
             let result = greater_than_chip.greater_than_witness(
                 layouter.namespace(|| "greater_than"),
-                F::from(self.x),
+                Value::known(F::from(self.x)),
                 F::from(self.y),
             )?;
 

--- a/src/gadgets/greater_than.rs
+++ b/src/gadgets/greater_than.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 
 use ff::PrimeFieldBits;
 use halo2_proofs::{
@@ -10,11 +9,13 @@ use halo2_proofs::{
 };
 
 use crate::utils::to_u32;
+use super::range_check::{self, RangeCheckConfig};
 
 pub struct GreaterThanWitnessResult<F: PrimeFieldBits> {
     pub x_cell: AssignedCell<F, F>,
     pub gt_cell: AssignedCell<F, F>,
 }
+
 
 pub trait GreaterThanInstructions<F: PrimeFieldBits> {
     /// Computes whether `x > y` by witnessing `x` and treating `y` as a constant.
@@ -22,7 +23,7 @@ pub trait GreaterThanInstructions<F: PrimeFieldBits> {
     /// Returns the assigned cell for `x` and the result (0 or 1).
     fn greater_than_witness(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: impl Layouter<F>,
         x: F,
         y: F,
     ) -> Result<GreaterThanWitnessResult<F>, Error>;
@@ -32,25 +33,26 @@ pub trait GreaterThanInstructions<F: PrimeFieldBits> {
     /// Returns the assigned cell with the result (0 or 1).
     fn greater_than_copy(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: impl Layouter<F>,
         x: &AssignedCell<F, F>,
         y: F,
     ) -> Result<AssignedCell<F, F>, Error>;
 }
 
 #[derive(Debug, Clone)]
-pub struct GreaterThanChipConfig {
+pub struct GreaterThanChipConfig<F: PrimeFieldBits> {
     x: Column<Advice>,
     y: Column<Advice>,
     diff: Column<Advice>,
     is_gt: Column<Advice>,
     selector: Selector,
+
+    range_check_config: RangeCheckConfig<F>,
 }
 
 #[derive(Debug, Clone)]
 pub struct GreaterThanChip<F: PrimeFieldBits> {
-    config: GreaterThanChipConfig,
-    _marker: PhantomData<F>,
+    config: GreaterThanChipConfig<F>,
 }
 
 /// Implements greater-than.
@@ -66,11 +68,8 @@ pub struct GreaterThanChip<F: PrimeFieldBits> {
 /// - is_gt is a bit
 /// - x + diff = 256 * is_gt + y
 impl<F: PrimeFieldBits> GreaterThanChip<F> {
-    pub fn construct(config: GreaterThanChipConfig) -> Self {
-        Self {
-            config,
-            _marker: PhantomData,
-        }
+    pub fn construct(config: GreaterThanChipConfig<F>) -> Self {
+        Self { config }
     }
 
     pub fn configure(
@@ -80,35 +79,36 @@ impl<F: PrimeFieldBits> GreaterThanChip<F> {
         diff: Column<Advice>,
         is_gt: Column<Advice>,
         byte_column: TableColumn,
-    ) -> GreaterThanChipConfig {
-        let selector = meta.complex_selector();
+        range_check_config: RangeCheckConfig<F>,
+    ) -> GreaterThanChipConfig<F> {
+        let selector = meta.selector();
 
-        meta.lookup("x is byte", |meta| {
-            let selector = meta.query_selector(selector);
+        // meta.lookup("x is byte", |meta| {
+        //     let selector = meta.query_selector(selector);
 
-            let x = meta.query_advice(x, Rotation::cur());
+        //     let x = meta.query_advice(x, Rotation::cur());
 
-            vec![(selector * x, byte_column)]
-        });
+        //     vec![(selector * x, byte_column)]
+        // });
 
-        meta.lookup("diff is byte", |meta| {
-            let selector = meta.query_selector(selector);
+        // meta.lookup("diff is byte", |meta| {
+        //     let selector = meta.query_selector(selector);
 
-            let diff = meta.query_advice(diff, Rotation::cur());
+        //     let diff = meta.query_advice(diff, Rotation::cur());
 
-            vec![(selector * diff, byte_column)]
-        });
+        //     vec![(selector * diff, byte_column)]
+        // });
 
-        meta.create_gate("is_gt is bit", |meta| {
-            let selector = meta.query_selector(selector);
+        // meta.create_gate("is_gt is bit", |meta| {
+        //     let selector = meta.query_selector(selector);
 
-            let is_gt = meta.query_advice(is_gt, Rotation::cur());
+        //     let is_gt = meta.query_advice(is_gt, Rotation::cur());
 
-            Constraints::with_selector(
-                selector,
-                vec![is_gt.clone() * (is_gt - Expression::Constant(F::ONE))],
-            )
-        });
+        //     Constraints::with_selector(
+        //         selector,
+        //         vec![is_gt.clone() * (is_gt - Expression::Constant(F::ONE))],
+        //     )
+        // });
 
         meta.create_gate("x + diff = 256 * is_gt + y", |meta| {
             let selector = meta.query_selector(selector);
@@ -129,6 +129,7 @@ impl<F: PrimeFieldBits> GreaterThanChip<F> {
             diff,
             is_gt,
             selector,
+            range_check_config,
         }
     }
 
@@ -137,7 +138,7 @@ impl<F: PrimeFieldBits> GreaterThanChip<F> {
         region: &mut Region<F>,
         x: &AssignedCell<F, F>,
         y: F,
-    ) -> Result<AssignedCell<F, F>, Error> {
+    ) -> Result<(AssignedCell<F, F>, AssignedCell<F, F>), Error> {
         if to_u32(&y) > 255 {
             panic!("y must be less than 256!");
         }
@@ -153,198 +154,228 @@ impl<F: PrimeFieldBits> GreaterThanChip<F> {
         self.config.selector.enable(region, 0)?;
 
         region.assign_advice_from_constant(|| "y", self.config.y, 0, y)?;
-        region.assign_advice(|| "diff", self.config.diff, 0, || diff)?;
-        region.assign_advice(|| "gt", self.config.is_gt, 0, || greater_than)
+        let diff_cell = region.assign_advice(|| "diff", self.config.diff, 0, || diff)?;
+        let gt_cell = region.assign_advice(|| "gt", self.config.is_gt, 0, || greater_than)?;
+
+        Ok((diff_cell, gt_cell))
     }
 }
 
 impl<F: PrimeFieldBits> GreaterThanInstructions<F> for GreaterThanChip<F> {
     fn greater_than_witness(
         &self,
-        layouter: &mut impl Layouter<F>,
+        mut layouter: impl Layouter<F>,
         x: F,
         y: F,
     ) -> Result<GreaterThanWitnessResult<F>, Error> {
-        layouter.assign_region(
+        let (x_cell, diff_cell, gt_cell) = layouter.assign_region(
             || "greater_than_witness",
             |mut region| {
                 let x_cell = region.assign_advice(|| "x", self.config.x, 0, || Value::known(x))?;
-                let gt_cell = self.greater_than(&mut region, &x_cell, y)?;
-                Ok(GreaterThanWitnessResult { x_cell, gt_cell })
+                let (diff_cell, result_cell) = self.greater_than(&mut region, &x_cell, y)?;
+                Ok((x_cell, diff_cell, result_cell))
             },
-        )
+        )?;
+        self.config.range_check_config.range_check(
+            layouter.namespace(|| "range_check_x"),
+            x_cell.clone(),
+            8,
+        )?;
+        self.config.range_check_config.range_check(
+            layouter.namespace(|| "range_check_gt"),
+            gt_cell.clone(),
+            1,
+        )?;
+        self.config.range_check_config.range_check(
+            layouter.namespace(|| "range_check_diff"),
+            diff_cell.clone(),
+            8,
+        )?;
+        Ok(GreaterThanWitnessResult {x_cell, gt_cell})
     }
 
     fn greater_than_copy(
         &self,
-        layouter: &mut impl Layouter<F>,
+        mut layouter: impl Layouter<F>,
         x: &AssignedCell<F, F>,
         y: F,
     ) -> Result<AssignedCell<F, F>, Error> {
-        layouter.assign_region(
+        let (diff_cell, result_cell) = layouter.assign_region(
             || "greater_than_copy",
             |mut region| {
                 let x_cell = x.copy_advice(|| "x", &mut region, self.config.x, 0)?;
                 self.greater_than(&mut region, &x_cell, y)
             },
-        )
+        )?;
+        self.config.range_check_config.range_check(
+            layouter.namespace(|| "range_check_gt"),
+            result_cell.clone(),
+            1,
+        )?;
+        self.config.range_check_config.range_check(
+            layouter.namespace(|| "range_check_diff"),
+            diff_cell.clone(),
+            8,
+        )?;
+        Ok(result_cell)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::marker::PhantomData;
+// #[cfg(test)]
+// mod tests {
+//     use std::marker::PhantomData;
 
-    use ff::{Field, PrimeFieldBits};
-    use halo2_proofs::{
-        circuit::{Layouter, SimpleFloorPlanner},
-        dev::MockProver,
-        halo2curves::bn256::Fr as Fp,
-        plonk::{Circuit, Column, ConstraintSystem, Error, Instance, TableColumn},
-    };
+//     use ff::{Field, PrimeFieldBits};
+//     use halo2_proofs::{
+//         circuit::{Layouter, SimpleFloorPlanner},
+//         dev::MockProver,
+//         halo2curves::bn256::Fr as Fp,
+//         plonk::{Circuit, Column, ConstraintSystem, Error, Instance, TableColumn},
+//     };
 
-    use crate::gadgets::range_check::load_bytes_column;
+//     use crate::gadgets::range_check::{load_bytes_column, RangeCheckConfig};
 
-    use super::{GreaterThanChip, GreaterThanChipConfig, GreaterThanInstructions};
+//     use super::{GreaterThanChip, GreaterThanChipConfig, GreaterThanInstructions};
 
-    /// Checks whether `x > y`, where `y` is a constant.
-    #[derive(Default)]
-    struct MyCircuit<F: PrimeFieldBits> {
-        x: u64,
-        y: u64,
-        _marker: PhantomData<F>,
-    }
+//     /// Checks whether `x > y`, where `y` is a constant.
+//     #[derive(Default)]
+//     struct MyCircuit<F: PrimeFieldBits> {
+//         x: u64,
+//         y: u64,
+//         _marker: PhantomData<F>,
+//     }
 
-    #[derive(Clone, Debug)]
-    struct Config {
-        greater_than_config: GreaterThanChipConfig,
-        table_column: TableColumn,
-        instance: Column<Instance>,
-    }
+//     #[derive(Clone, Debug)]
+//     struct Config<F: PrimeFieldBits> {
+//         greater_than_config: GreaterThanChipConfig<F>,
+//         table_column: TableColumn,
+//         instance: Column<Instance>,
+//     }
 
-    impl<F: PrimeFieldBits> Circuit<F> for MyCircuit<F> {
-        type Config = Config;
-        type FloorPlanner = SimpleFloorPlanner;
-        type Params = ();
+//     impl<F: PrimeFieldBits> Circuit<F> for MyCircuit<F> {
+//         type Config = Config<F>;
+//         type FloorPlanner = SimpleFloorPlanner;
+//         type Params = ();
 
-        fn without_witnesses(&self) -> Self {
-            Self::default()
-        }
+//         fn without_witnesses(&self) -> Self {
+//             Self::default()
+//         }
 
-        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-            let x = meta.advice_column();
-            let y = meta.advice_column();
-            let diff = meta.advice_column();
-            let is_gt = meta.advice_column();
+//         fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+//             let x = meta.advice_column();
+//             let y = meta.advice_column();
+//             let diff = meta.advice_column();
+//             let is_gt = meta.advice_column();
 
-            let table_column = meta.lookup_table_column();
-            let constants = meta.fixed_column();
-            let instance = meta.instance_column();
+//             let table_column = meta.lookup_table_column();
+//             let constants = meta.fixed_column();
+//             let instance = meta.instance_column();
 
-            meta.enable_equality(x);
-            meta.enable_equality(y);
-            meta.enable_equality(is_gt);
-            meta.enable_equality(instance);
-            meta.enable_constant(constants);
+//             meta.enable_equality(x);
+//             meta.enable_equality(y);
+//             meta.enable_equality(is_gt);
+//             meta.enable_equality(instance);
+//             meta.enable_constant(constants);
 
-            let range_check_config =
-                GreaterThanChip::configure(meta, x, y, diff, is_gt, table_column);
+//             let range_check_config = RangeCheckConfig::configure(meta, x, byte_column);
+//             let greater_than_config =
+//                 GreaterThanChip::configure(meta, x, y, diff, is_gt, table_column, range_check_config);
 
-            Config {
-                greater_than_config: range_check_config,
-                table_column,
-                instance,
-            }
-        }
+//             Config {
+//                 greater_than_config,
+//                 table_column,
+//                 instance,
+//             }
+//         }
 
-        fn synthesize(
-            &self,
-            config: Self::Config,
-            mut layouter: impl Layouter<F>,
-        ) -> Result<(), Error> {
-            load_bytes_column(&mut layouter, config.table_column)?;
-            let greater_than_chip = GreaterThanChip::construct(config.greater_than_config);
-            let result = greater_than_chip.greater_than_witness(
-                &mut layouter,
-                F::from(self.x),
-                F::from(self.y),
-            )?;
+    //     fn synthesize(
+    //         &self,
+    //         config: Self::Config,
+    //         mut layouter: impl Layouter<F>,
+    //     ) -> Result<(), Error> {
+    //         load_bytes_column(&mut layouter, config.table_column)?;
+    //         let greater_than_chip = GreaterThanChip::construct(config.greater_than_config);
+    //         let result = greater_than_chip.greater_than_witness(
+    //             &mut layouter,
+    //             F::from(self.x),
+    //             F::from(self.y),
+    //         )?;
 
-            layouter.constrain_instance(result.gt_cell.cell(), config.instance, 0)?;
-            Ok(())
-        }
-    }
+    //         layouter.constrain_instance(result.gt_cell.cell(), config.instance, 0)?;
+    //         Ok(())
+    //     }
+    // }
 
-    #[test]
-    fn test_gt_true() {
-        let k = 9;
-        let circuit = MyCircuit::<Fp> {
-            x: 129,
-            y: 64,
-            _marker: PhantomData,
-        };
-        let output = Fp::ONE;
-        let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
-        prover.assert_satisfied();
-    }
+//     #[test]
+//     fn test_gt_true() {
+//         let k = 9;
+//         let circuit = MyCircuit::<Fp> {
+//             x: 129,
+//             y: 64,
+//             _marker: PhantomData,
+//         };
+//         let output = Fp::ONE;
+//         let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
+//         prover.assert_satisfied();
+//     }
 
-    #[test]
-    fn test_gt_false() {
-        let k = 9;
-        let circuit = MyCircuit::<Fp> {
-            x: 64,
-            y: 129,
-            _marker: PhantomData,
-        };
-        let output = Fp::ZERO;
-        let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
-        prover.assert_satisfied();
-    }
+//     #[test]
+//     fn test_gt_false() {
+//         let k = 9;
+//         let circuit = MyCircuit::<Fp> {
+//             x: 64,
+//             y: 129,
+//             _marker: PhantomData,
+//         };
+//         let output = Fp::ZERO;
+//         let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
+//         prover.assert_satisfied();
+//     }
 
-    #[test]
-    fn test_gt_equal() {
-        let k = 9;
-        let circuit = MyCircuit::<Fp> {
-            x: 64,
-            y: 64,
-            _marker: PhantomData,
-        };
-        let output = Fp::ZERO;
-        let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
-        prover.assert_satisfied();
-    }
+//     #[test]
+//     fn test_gt_equal() {
+//         let k = 9;
+//         let circuit = MyCircuit::<Fp> {
+//             x: 64,
+//             y: 64,
+//             _marker: PhantomData,
+//         };
+//         let output = Fp::ZERO;
+//         let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
+//         prover.assert_satisfied();
+//     }
 
-    #[test]
-    fn test_x_too_large() {
-        let k = 9;
-        let circuit = MyCircuit::<Fp> {
-            x: 256,
-            y: 64,
-            _marker: PhantomData,
-        };
-        let output = Fp::ZERO;
-        let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
-        assert!(prover.verify().is_err());
-    }
+//     #[test]
+//     fn test_x_too_large() {
+//         let k = 9;
+//         let circuit = MyCircuit::<Fp> {
+//             x: 256,
+//             y: 64,
+//             _marker: PhantomData,
+//         };
+//         let output = Fp::ZERO;
+//         let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
+//         assert!(prover.verify().is_err());
+//     }
 
-    #[test]
-    fn plot() {
-        use plotters::prelude::*;
+//     #[test]
+//     fn plot() {
+//         use plotters::prelude::*;
 
-        let root = BitMapBackend::new("gt-layout.png", (512, 1024)).into_drawing_area();
-        root.fill(&WHITE).unwrap();
-        let root = root
-            .titled("Greater Than Layout", ("sans-serif", 60))
-            .unwrap();
+//         let root = BitMapBackend::new("gt-layout.png", (512, 1024)).into_drawing_area();
+//         root.fill(&WHITE).unwrap();
+//         let root = root
+//             .titled("Greater Than Layout", ("sans-serif", 60))
+//             .unwrap();
 
-        let circuit = MyCircuit::<Fp> {
-            x: 129,
-            y: 64,
-            _marker: PhantomData,
-        };
-        halo2_proofs::dev::CircuitLayout::default()
-            .show_labels(true)
-            .render(5, &circuit, &root)
-            .unwrap();
-    }
-}
+//         let circuit = MyCircuit::<Fp> {
+//             x: 129,
+//             y: 64,
+//             _marker: PhantomData,
+//         };
+//         halo2_proofs::dev::CircuitLayout::default()
+//             .show_labels(true)
+//             .render(5, &circuit, &root)
+//             .unwrap();
+//     }
+// }

--- a/src/gadgets/greater_than.rs
+++ b/src/gadgets/greater_than.rs
@@ -15,7 +15,7 @@ pub struct GreaterThanWitnessResult<F: PrimeFieldBits> {
 
 pub trait GreaterThanInstructions<F: PrimeFieldBits> {
     /// Computes whether `x > y` by witnessing `x` and treating `y` as a constant.
-    /// Note that both `x` and `y` are assumed to be bytes (on `x`, this is enforced; `y` us a public constant).
+    /// Note that both `x` and `y` are assumed to be bytes (on `x`, this is enforced; `y` is a public constant).
     /// Returns the assigned cell for `x` and the result (0 or 1).
     fn greater_than_witness(
         &self,
@@ -25,7 +25,8 @@ pub trait GreaterThanInstructions<F: PrimeFieldBits> {
     ) -> Result<GreaterThanWitnessResult<F>, Error>;
 
     /// Computes whether `x > y` by copying `x` from an existing cell and treating `y` as a constant.
-    /// Note that both `x` and `y` are assumed to be bytes (on `x`, this is enforced; `y` us a public constant).
+    /// Note that both `x` and `y` are assumed to be bytes (on `x`, this should be enforced on whatever
+    /// cell it's copied from; `y` is a public constant).
     /// Returns the assigned cell with the result (0 or 1).
     fn greater_than_copy(
         &self,
@@ -59,9 +60,9 @@ pub struct GreaterThanChip<F: PrimeFieldBits> {
 /// | b (copy or witness) | t (constant) | 256 * is_gt + t - b | b > t |
 ///
 /// The following constraints are enforced:
-/// - x is a byte (via a lookup table)
-/// - diff is a byte (via a lookup table)
-/// - is_gt is a bit
+/// - x is a byte (if witnessed, via RangeCheckConfig)
+/// - diff is a byte (via RangeCheckConfig)
+/// - is_gt is a bit (via RangeCheckConfig)
 /// - x + diff = 256 * is_gt + y
 impl<F: PrimeFieldBits> GreaterThanChip<F> {
     pub fn construct(config: GreaterThanChipConfig<F>) -> Self {

--- a/src/gadgets/greater_than.rs
+++ b/src/gadgets/greater_than.rs
@@ -1,21 +1,17 @@
-
 use ff::PrimeFieldBits;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region, Value},
-    plonk::{
-        Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector, TableColumn,
-    },
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 
+use super::range_check::RangeCheckConfig;
 use crate::utils::to_u32;
-use super::range_check::{self, RangeCheckConfig};
 
 pub struct GreaterThanWitnessResult<F: PrimeFieldBits> {
     pub x_cell: AssignedCell<F, F>,
     pub gt_cell: AssignedCell<F, F>,
 }
-
 
 pub trait GreaterThanInstructions<F: PrimeFieldBits> {
     /// Computes whether `x > y` by witnessing `x` and treating `y` as a constant.
@@ -78,37 +74,9 @@ impl<F: PrimeFieldBits> GreaterThanChip<F> {
         y: Column<Advice>,
         diff: Column<Advice>,
         is_gt: Column<Advice>,
-        byte_column: TableColumn,
         range_check_config: RangeCheckConfig<F>,
     ) -> GreaterThanChipConfig<F> {
         let selector = meta.selector();
-
-        // meta.lookup("x is byte", |meta| {
-        //     let selector = meta.query_selector(selector);
-
-        //     let x = meta.query_advice(x, Rotation::cur());
-
-        //     vec![(selector * x, byte_column)]
-        // });
-
-        // meta.lookup("diff is byte", |meta| {
-        //     let selector = meta.query_selector(selector);
-
-        //     let diff = meta.query_advice(diff, Rotation::cur());
-
-        //     vec![(selector * diff, byte_column)]
-        // });
-
-        // meta.create_gate("is_gt is bit", |meta| {
-        //     let selector = meta.query_selector(selector);
-
-        //     let is_gt = meta.query_advice(is_gt, Rotation::cur());
-
-        //     Constraints::with_selector(
-        //         selector,
-        //         vec![is_gt.clone() * (is_gt - Expression::Constant(F::ONE))],
-        //     )
-        // });
 
         meta.create_gate("x + diff = 256 * is_gt + y", |meta| {
             let selector = meta.query_selector(selector);
@@ -191,7 +159,7 @@ impl<F: PrimeFieldBits> GreaterThanInstructions<F> for GreaterThanChip<F> {
             diff_cell.clone(),
             8,
         )?;
-        Ok(GreaterThanWitnessResult {x_cell, gt_cell})
+        Ok(GreaterThanWitnessResult { x_cell, gt_cell })
     }
 
     fn greater_than_copy(
@@ -221,161 +189,162 @@ impl<F: PrimeFieldBits> GreaterThanInstructions<F> for GreaterThanChip<F> {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use std::marker::PhantomData;
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
 
-//     use ff::{Field, PrimeFieldBits};
-//     use halo2_proofs::{
-//         circuit::{Layouter, SimpleFloorPlanner},
-//         dev::MockProver,
-//         halo2curves::bn256::Fr as Fp,
-//         plonk::{Circuit, Column, ConstraintSystem, Error, Instance, TableColumn},
-//     };
+    use ff::{Field, PrimeFieldBits};
+    use halo2_proofs::{
+        circuit::{Layouter, SimpleFloorPlanner},
+        dev::MockProver,
+        halo2curves::bn256::Fr as Fp,
+        plonk::{Circuit, Column, ConstraintSystem, Error, Instance, TableColumn},
+    };
 
-//     use crate::gadgets::range_check::{load_bytes_column, RangeCheckConfig};
+    use crate::gadgets::range_check::{load_bytes_column, RangeCheckConfig};
 
-//     use super::{GreaterThanChip, GreaterThanChipConfig, GreaterThanInstructions};
+    use super::{GreaterThanChip, GreaterThanChipConfig, GreaterThanInstructions};
 
-//     /// Checks whether `x > y`, where `y` is a constant.
-//     #[derive(Default)]
-//     struct MyCircuit<F: PrimeFieldBits> {
-//         x: u64,
-//         y: u64,
-//         _marker: PhantomData<F>,
-//     }
+    /// Checks whether `x > y`, where `y` is a constant.
+    #[derive(Default)]
+    struct MyCircuit<F: PrimeFieldBits> {
+        x: u64,
+        y: u64,
+        _marker: PhantomData<F>,
+    }
 
-//     #[derive(Clone, Debug)]
-//     struct Config<F: PrimeFieldBits> {
-//         greater_than_config: GreaterThanChipConfig<F>,
-//         table_column: TableColumn,
-//         instance: Column<Instance>,
-//     }
+    #[derive(Clone, Debug)]
+    struct Config<F: PrimeFieldBits> {
+        greater_than_config: GreaterThanChipConfig<F>,
+        byte_column: TableColumn,
+        instance: Column<Instance>,
+    }
 
-//     impl<F: PrimeFieldBits> Circuit<F> for MyCircuit<F> {
-//         type Config = Config<F>;
-//         type FloorPlanner = SimpleFloorPlanner;
-//         type Params = ();
+    impl<F: PrimeFieldBits> Circuit<F> for MyCircuit<F> {
+        type Config = Config<F>;
+        type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
-//         fn without_witnesses(&self) -> Self {
-//             Self::default()
-//         }
+        fn without_witnesses(&self) -> Self {
+            Self::default()
+        }
 
-//         fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-//             let x = meta.advice_column();
-//             let y = meta.advice_column();
-//             let diff = meta.advice_column();
-//             let is_gt = meta.advice_column();
+        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            let x = meta.advice_column();
+            let y = meta.advice_column();
+            let diff = meta.advice_column();
+            let is_gt = meta.advice_column();
 
-//             let table_column = meta.lookup_table_column();
-//             let constants = meta.fixed_column();
-//             let instance = meta.instance_column();
+            let byte_column = meta.lookup_table_column();
+            let constants = meta.fixed_column();
+            let instance = meta.instance_column();
 
-//             meta.enable_equality(x);
-//             meta.enable_equality(y);
-//             meta.enable_equality(is_gt);
-//             meta.enable_equality(instance);
-//             meta.enable_constant(constants);
+            meta.enable_equality(x);
+            meta.enable_equality(y);
+            meta.enable_equality(diff);
+            meta.enable_equality(is_gt);
+            meta.enable_equality(instance);
+            meta.enable_constant(constants);
 
-//             let range_check_config = RangeCheckConfig::configure(meta, x, byte_column);
-//             let greater_than_config =
-//                 GreaterThanChip::configure(meta, x, y, diff, is_gt, table_column, range_check_config);
+            let range_check_config = RangeCheckConfig::configure(meta, x, byte_column);
+            let greater_than_config =
+                GreaterThanChip::configure(meta, x, y, diff, is_gt, range_check_config);
 
-//             Config {
-//                 greater_than_config,
-//                 table_column,
-//                 instance,
-//             }
-//         }
+            Config {
+                greater_than_config,
+                byte_column,
+                instance,
+            }
+        }
 
-    //     fn synthesize(
-    //         &self,
-    //         config: Self::Config,
-    //         mut layouter: impl Layouter<F>,
-    //     ) -> Result<(), Error> {
-    //         load_bytes_column(&mut layouter, config.table_column)?;
-    //         let greater_than_chip = GreaterThanChip::construct(config.greater_than_config);
-    //         let result = greater_than_chip.greater_than_witness(
-    //             &mut layouter,
-    //             F::from(self.x),
-    //             F::from(self.y),
-    //         )?;
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            load_bytes_column(&mut layouter, config.byte_column)?;
+            let greater_than_chip = GreaterThanChip::construct(config.greater_than_config);
+            let result = greater_than_chip.greater_than_witness(
+                layouter.namespace(|| "greater_than"),
+                F::from(self.x),
+                F::from(self.y),
+            )?;
 
-    //         layouter.constrain_instance(result.gt_cell.cell(), config.instance, 0)?;
-    //         Ok(())
-    //     }
-    // }
+            layouter.constrain_instance(result.gt_cell.cell(), config.instance, 0)?;
+            Ok(())
+        }
+    }
 
-//     #[test]
-//     fn test_gt_true() {
-//         let k = 9;
-//         let circuit = MyCircuit::<Fp> {
-//             x: 129,
-//             y: 64,
-//             _marker: PhantomData,
-//         };
-//         let output = Fp::ONE;
-//         let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
-//         prover.assert_satisfied();
-//     }
+    #[test]
+    fn test_gt_true() {
+        let k = 9;
+        let circuit = MyCircuit::<Fp> {
+            x: 129,
+            y: 64,
+            _marker: PhantomData,
+        };
+        let output = Fp::ONE;
+        let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
+        prover.assert_satisfied();
+    }
 
-//     #[test]
-//     fn test_gt_false() {
-//         let k = 9;
-//         let circuit = MyCircuit::<Fp> {
-//             x: 64,
-//             y: 129,
-//             _marker: PhantomData,
-//         };
-//         let output = Fp::ZERO;
-//         let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
-//         prover.assert_satisfied();
-//     }
+    #[test]
+    fn test_gt_false() {
+        let k = 9;
+        let circuit = MyCircuit::<Fp> {
+            x: 64,
+            y: 129,
+            _marker: PhantomData,
+        };
+        let output = Fp::ZERO;
+        let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
+        prover.assert_satisfied();
+    }
 
-//     #[test]
-//     fn test_gt_equal() {
-//         let k = 9;
-//         let circuit = MyCircuit::<Fp> {
-//             x: 64,
-//             y: 64,
-//             _marker: PhantomData,
-//         };
-//         let output = Fp::ZERO;
-//         let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
-//         prover.assert_satisfied();
-//     }
+    #[test]
+    fn test_gt_equal() {
+        let k = 9;
+        let circuit = MyCircuit::<Fp> {
+            x: 64,
+            y: 64,
+            _marker: PhantomData,
+        };
+        let output = Fp::ZERO;
+        let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
+        prover.assert_satisfied();
+    }
 
-//     #[test]
-//     fn test_x_too_large() {
-//         let k = 9;
-//         let circuit = MyCircuit::<Fp> {
-//             x: 256,
-//             y: 64,
-//             _marker: PhantomData,
-//         };
-//         let output = Fp::ZERO;
-//         let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
-//         assert!(prover.verify().is_err());
-//     }
+    #[test]
+    fn test_x_too_large() {
+        let k = 9;
+        let circuit = MyCircuit::<Fp> {
+            x: 256,
+            y: 64,
+            _marker: PhantomData,
+        };
+        let output = Fp::ZERO;
+        let prover = MockProver::run(k, &circuit, vec![vec![output]]).unwrap();
+        assert!(prover.verify().is_err());
+    }
 
-//     #[test]
-//     fn plot() {
-//         use plotters::prelude::*;
+    #[test]
+    fn plot() {
+        use plotters::prelude::*;
 
-//         let root = BitMapBackend::new("gt-layout.png", (512, 1024)).into_drawing_area();
-//         root.fill(&WHITE).unwrap();
-//         let root = root
-//             .titled("Greater Than Layout", ("sans-serif", 60))
-//             .unwrap();
+        let root = BitMapBackend::new("gt-layout.png", (512, 1024)).into_drawing_area();
+        root.fill(&WHITE).unwrap();
+        let root = root
+            .titled("Greater Than Layout", ("sans-serif", 60))
+            .unwrap();
 
-//         let circuit = MyCircuit::<Fp> {
-//             x: 129,
-//             y: 64,
-//             _marker: PhantomData,
-//         };
-//         halo2_proofs::dev::CircuitLayout::default()
-//             .show_labels(true)
-//             .render(5, &circuit, &root)
-//             .unwrap();
-//     }
-// }
+        let circuit = MyCircuit::<Fp> {
+            x: 129,
+            y: 64,
+            _marker: PhantomData,
+        };
+        halo2_proofs::dev::CircuitLayout::default()
+            .show_labels(true)
+            .render(5, &circuit, &root)
+            .unwrap();
+    }
+}

--- a/src/gadgets/greater_than.rs
+++ b/src/gadgets/greater_than.rs
@@ -101,6 +101,7 @@ impl<F: PrimeFieldBits> GreaterThanChip<F> {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     fn greater_than(
         &self,
         region: &mut Region<F>,
@@ -156,7 +157,7 @@ impl<F: PrimeFieldBits> GreaterThanInstructions<F> for GreaterThanChip<F> {
         )?;
         self.config.range_check_config.range_check(
             layouter.namespace(|| "range_check_diff"),
-            diff_cell.clone(),
+            diff_cell,
             8,
         )?;
         Ok(GreaterThanWitnessResult { x_cell, gt_cell })
@@ -182,7 +183,7 @@ impl<F: PrimeFieldBits> GreaterThanInstructions<F> for GreaterThanChip<F> {
         )?;
         self.config.range_check_config.range_check(
             layouter.namespace(|| "range_check_diff"),
-            diff_cell.clone(),
+            diff_cell,
             8,
         )?;
         Ok(result_cell)

--- a/src/gadgets/wnn.rs
+++ b/src/gadgets/wnn.rs
@@ -348,11 +348,6 @@ impl<F: PrimeFieldBits> Circuit<F> for WnnCircuit<F> {
         let constants = meta.fixed_column();
         meta.enable_constant(constants);
 
-        // Sometimes, one column of constants is not enough
-        // (Especially with the "V1" floor planner, as it packs more efficiently)
-        let constants2 = meta.fixed_column();
-        meta.enable_constant(constants2);
-
         let bloom_filter_config = BloomFilterConfig {
             n_hashes: params.n_hashes,
             bits_per_hash: params.bits_per_hash,

--- a/src/gadgets/wnn.rs
+++ b/src/gadgets/wnn.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use ff::PrimeFieldBits;
 use halo2_proofs::{
-    circuit::{floor_planner::V1, AssignedCell, Layouter, Value},
+    circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value},
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Instance},
 };
 use ndarray::{Array1, Array2, Array3};
@@ -302,7 +302,15 @@ impl Default for WnnCircuitParams {
 
 impl<F: PrimeFieldBits> Circuit<F> for WnnCircuit<F> {
     type Config = WnnCircuitConfig<F>;
-    type FloorPlanner = V1;
+
+    // The V1 floor planner could be used for fewer number of rows,
+    // but unfortunately, it has aproving time overhead of ~30%.
+    // Also, it rarely leads to smaller values of `k` in practice,
+    // so we stick with SimpleFloorPlanner for now.
+    // In principle, there is no good reason for a proving time overhead
+    // of floor planning, and there are plans to get rid of it:
+    // https://github.com/zcash/halo2/issues/643
+    type FloorPlanner = SimpleFloorPlanner;
     type Params = WnnCircuitParams;
 
     fn without_witnesses(&self) -> Self {

--- a/src/gadgets/wnn.rs
+++ b/src/gadgets/wnn.rs
@@ -143,8 +143,6 @@ impl<F: PrimeFieldBits> WnnChip<F> {
             advice_columns[1],
             advice_columns[2],
             advice_columns[3],
-            // Re-use byte column of the bloom filter
-            bloom_filter_chip_config.byte_column,
             lookup_range_check_config.clone(),
         );
         let hash_chip_config = HashChip::configure(

--- a/src/gadgets/wnn.rs
+++ b/src/gadgets/wnn.rs
@@ -43,7 +43,7 @@ pub struct WnnConfig {
 
 #[derive(Clone, Debug)]
 pub struct WnnChipConfig<F: PrimeFieldBits> {
-    encode_image_chip_config: EncodeImageChipConfig,
+    encode_image_chip_config: EncodeImageChipConfig<F>,
     bits2num_chip_config: Bits2NumChipConfig,
     hash_chip_config: HashConfig<F>,
     bloom_filter_chip_config: BloomFilterChipConfig,
@@ -131,6 +131,12 @@ impl<F: PrimeFieldBits> WnnChip<F> {
             advice_columns,
             wnn_config.bloom_filter_config.clone(),
         );
+        let lookup_range_check_config = RangeCheckConfig::configure(
+            meta,
+            advice_columns[3],
+            // Re-use byte column of the bloom filter
+            bloom_filter_chip_config.byte_column,
+        );
         let encode_image_chip_config = EncodeImageChip::configure(
             meta,
             advice_columns[0],
@@ -139,12 +145,7 @@ impl<F: PrimeFieldBits> WnnChip<F> {
             advice_columns[3],
             // Re-use byte column of the bloom filter
             bloom_filter_chip_config.byte_column,
-        );
-        let lookup_range_check_config = RangeCheckConfig::configure(
-            meta,
-            advice_columns[5],
-            // Re-use byte column of the bloom filter
-            bloom_filter_chip_config.byte_column,
+            lookup_range_check_config.clone(),
         );
         let hash_chip_config = HashChip::configure(
             meta,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,8 @@ pub use wnn::Wnn;
 
 pub mod checked_in_test_data {
     pub const TEST_IMG_PATH: &str = "benches/example_image_7.png";
-    pub const MNIST_TINY: (u32, &str) = (14, "models/model_28input_256entry_1hash_1bpi.hdf5");
+    pub const MNIST_TINY: (u32, &str) = (13, "models/model_28input_256entry_1hash_1bpi.hdf5");
     pub const MNIST_SMALL: (u32, &str) = (15, "models/model_28input_1024entry_2hash_2bpi.hdf5");
-    pub const MNIST_MEDIUM: (u32, &str) = (16, "models/model_28input_2048entry_2hash_3bpi.hdf5");
+    pub const MNIST_MEDIUM: (u32, &str) = (15, "models/model_28input_2048entry_2hash_3bpi.hdf5");
     pub const MNIST_LARGE: (u32, &str) = (17, "models/model_49input_8192entry_4hash_6bpi.hdf5");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,8 @@ pub use wnn::Wnn;
 
 pub mod checked_in_test_data {
     pub const TEST_IMG_PATH: &str = "benches/example_image_7.png";
-    pub const MNIST_TINY: (u32, &str) = (12, "models/model_28input_256entry_1hash_1bpi.hdf5");
+    pub const MNIST_TINY: (u32, &str) = (14, "models/model_28input_256entry_1hash_1bpi.hdf5");
     pub const MNIST_SMALL: (u32, &str) = (15, "models/model_28input_1024entry_2hash_2bpi.hdf5");
-    pub const MNIST_MEDIUM: (u32, &str) = (15, "models/model_28input_2048entry_2hash_3bpi.hdf5");
+    pub const MNIST_MEDIUM: (u32, &str) = (16, "models/model_28input_2048entry_2hash_3bpi.hdf5");
     pub const MNIST_LARGE: (u32, &str) = (17, "models/model_49input_8192entry_4hash_6bpi.hdf5");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,9 @@ pub use wnn::Wnn;
 
 pub mod checked_in_test_data {
     pub const TEST_IMG_PATH: &str = "benches/example_image_7.png";
-    pub const MNIST_TINY: (u32, &str) = (13, "models/model_28input_256entry_1hash_1bpi.hdf5");
+
+    // For each model, we store the path and the minimal value for `k` needed (assuming SimpleFloorPlanner)
+    pub const MNIST_TINY: (u32, &str) = (14, "models/model_28input_256entry_1hash_1bpi.hdf5");
     pub const MNIST_SMALL: (u32, &str) = (15, "models/model_28input_1024entry_2hash_2bpi.hdf5");
     pub const MNIST_MEDIUM: (u32, &str) = (15, "models/model_28input_2048entry_2hash_3bpi.hdf5");
     pub const MNIST_LARGE: (u32, &str) = (17, "models/model_49input_8192entry_4hash_6bpi.hdf5");


### PR DESCRIPTION
This PR gets rid of 2 table lookups and 1 gate in the `GreaterThanChip` by range-checking using the existing gadget, as suggested in #14.

This increases the required value for `k` from 12 to 14 for the `MNIST-Tiny` model, but has no effect on the "real-world" models. For those models, proofs are ~13% faster and the size of the verifier is now small enough to fit into an Ethereum smart contract! 🥳 

I also tested switching to the `V1` floor planner. Unfortunatey, it has a ~30% proving-time overhead and only reduces `k` for the `MNIST-Tiny` model (to 13). So, I undid this change (but keeping the proper implementation of `Circuit::without_witness()` needed for the `V1` floor planner). Once https://github.com/zcash/halo2/issues/643 is resolved, proof-time synthesis of should not be necessary anymore and we can move to the `V1` planner.

The benchmarks show an increase of proving time for `MINST-Tiny` (because of the higher value of `k`) and a decrease in proving time otherwise:
```
benches/key_generation_mnist_tiny
                        time:   [2.3072 s 2.3643 s 2.4244 s]
                        change: [+150.63% +159.31% +168.44%] (p = 0.00 < 0.05)
                        Performance has regressed.
benches/proof_generation_mnist_tiny
                        time:   [3.6469 s 3.6879 s 3.7302 s]
                        change: [+126.81% +134.23% +142.59%] (p = 0.00 < 0.05)
                        Performance has regressed.
benches/verification_mnist_tiny
                        time:   [13.714 ms 14.260 ms 14.699 ms]
                        change: [-2.8173% +3.7090% +11.500%] (p = 0.34 > 0.05)
                        No change in performance detected.
benches/proof_generation_mnist_small
                        time:   [6.7773 s 6.8724 s 6.9471 s]
                        change: [-15.671% -13.926% -12.071%] (p = 0.00 < 0.05)
                        Performance has improved.
benches/verification_mnist_small
                        time:   [13.835 ms 14.369 ms 15.008 ms]
                        change: [-9.8799% -3.8734% +2.3501%] (p = 0.27 > 0.05)
                        No change in performance detected.
benches/proof_generation_mnist_medium
                        time:   [6.9457 s 7.0208 s 7.0903 s]
                        change: [-15.176% -13.268% -11.329%] (p = 0.00 < 0.05)
                        Performance has improved.
benches/verification_mnist_medium
                        time:   [13.778 ms 14.315 ms 15.028 ms]
                        change: [-8.8268% -4.0115% +1.3125%] (p = 0.17 > 0.05)
                        No change in performance detected.
```